### PR TITLE
Update main CMake defaulting on ChibiOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,18 +40,23 @@ endif()
 #######################
 # handle RTOSes choice
 
-# sanity check here for invalid RTOS option
-set(RTOS_SUPPORTED CHIBIOS FREERTOS MBEDOS RTXRTOS RTXRTOS2 CACHE INTERNAL "supported RTOS options")
-list(FIND RTOS_SUPPORTED ${RTOS} RTOS_INDEX)
-if(RTOS_INDEX EQUAL -1)
-    message(FATAL_ERROR "\n\nSorry but ${RTOS} is not supported at this time...\nYou can wait for that to be added or you might want to contribute and start working on a PR for that.\n\n")
-endif()
+# # sanity check here for invalid RTOS option
+# set(RTOS_SUPPORTED CHIBIOS FREERTOS MBEDOS RTXRTOS RTXRTOS2 CACHE INTERNAL "supported RTOS options")
+# list(FIND RTOS_SUPPORTED ${RTOS} RTOS_INDEX)
+# if(RTOS_INDEX EQUAL -1)
+#     message(FATAL_ERROR "\n\nSorry but ${RTOS} is not supported at this time...\nYou can wait for that to be added or you might want to contribute and start working on a PR for that.\n\n")
+# endif()
 
-string(COMPARE EQUAL "CHIBIOS" "${RTOS}"  RTOS_CHIBIOS_CHECK)
-string(COMPARE EQUAL "FREERTOS" "${RTOS}" RTOS_FREERTOS_CHECK)
-string(COMPARE EQUAL "MBEDOS"   "${RTOS}" RTOS_MBEDOS_CHECK)
-string(COMPARE EQUAL "RTXRTOS"  "${RTOS}" RTOS_RTX_RTOS_CHECK)
-string(COMPARE EQUAL "RTXRTOS2" "${RTOS}" RTOS_RTX_RTOS2_CHECK)
+# string(COMPARE EQUAL "CHIBIOS" "${RTOS}"  RTOS_CHIBIOS_CHECK)
+# string(COMPARE EQUAL "FREERTOS" "${RTOS}" RTOS_FREERTOS_CHECK)
+# string(COMPARE EQUAL "MBEDOS"   "${RTOS}" RTOS_MBEDOS_CHECK)
+# string(COMPARE EQUAL "RTXRTOS"  "${RTOS}" RTOS_RTX_RTOS_CHECK)
+# string(COMPARE EQUAL "RTXRTOS2" "${RTOS}" RTOS_RTX_RTOS2_CHECK)
+
+##########################################################################
+# default RTOS choice is ChibiOS (no other RTOS is supported at this time)
+set(RTOS_CHIBIOS_CHECK TRUE)
+##########################################################################
 
 if(RTOS_FREERTOS_CHECK) 
     set(RTOS_FREERTOS_CHECK TRUE)
@@ -109,42 +114,42 @@ if(RTOS_CHIBIOS_CHECK)
     # set toolchain file
     set(CMAKE_TOOLCHAIN_FILE CMake/toolchain.ChibiOS.${TOOLCHAIN}.cmake)
 
-elseif(RTOS_MBEDOS_CHECK)
+# elseif(RTOS_MBEDOS_CHECK)
 
-    message(STATUS "\nSetting Toolchain file for mbed \n")
-    # set toolchain file
-    set(CMAKE_TOOLCHAIN_FILE CMake/toolchain.mbed.${TOOLCHAIN}.cmake)
+#     message(STATUS "\nSetting Toolchain file for mbed \n")
+#     # set toolchain file
+#     set(CMAKE_TOOLCHAIN_FILE CMake/toolchain.mbed.${TOOLCHAIN}.cmake)
 
-else()
+# else()
 
-    # find out the chip vendor in order to move on with the appropriate configuration
-    string(REGEX MATCH "^[S][T][M]32" CHIP_VENDOR_STM32 "${TARGET_CHIP}")
-    string(COMPARE EQUAL "STM32" "${CHIP_VENDOR_STM32}" CHIP_VENDOR_STM32_CHECK)
+#     # find out the chip vendor in order to move on with the appropriate configuration
+#     string(REGEX MATCH "^[S][T][M]32" CHIP_VENDOR_STM32 "${TARGET_CHIP}")
+#     string(COMPARE EQUAL "STM32" "${CHIP_VENDOR_STM32}" CHIP_VENDOR_STM32_CHECK)
 
-    if(CHIP_VENDOR_STM32_CHECK)
-        # vendor is ST and toolchain is GCC
-        message(STATUS "Chip vendor is ST. Chip is STM32.")
+#     if(CHIP_VENDOR_STM32_CHECK)
+#         # vendor is ST and toolchain is GCC
+#         message(STATUS "Chip vendor is ST. Chip is STM32.")
 
-        # set CMSIS include directories
-        include_directories(STM32CMSIS_INCLUDE_DIRS)
+#         # set CMSIS include directories
+#         include_directories(STM32CMSIS_INCLUDE_DIRS)
 
-        # set toolchain file for cross-compiling with CMake
-        # for this vendor/chip it will be 
-    # elseif(CHIP_VENDOR_??_CHECK)
-    #
-    #     # vendor is ?? and toolchain is GCC
-    #     message("Chip vendor is ??. Chip is ???.")
-    #     set(CMAKE_TOOLCHAIN_FILE CMake/???.cmake)
-    # 
-    else()
-        message(STATUS "\n-- ###############################################\n")
-        message(STATUS "Unknow vendor or chip. Supported vendors/chips:\n-- ST's STM32 (e.g. STM32F407VG)\n")
-        message(STATUS "###############################################\n\n")
-        message(FATAL_ERROR "Unknow vendor or chip in TARGET_CHIP")
-    endif()
+#         # set toolchain file for cross-compiling with CMake
+#         # for this vendor/chip it will be 
+#     # elseif(CHIP_VENDOR_??_CHECK)
+#     #
+#     #     # vendor is ?? and toolchain is GCC
+#     #     message("Chip vendor is ??. Chip is ???.")
+#     #     set(CMAKE_TOOLCHAIN_FILE CMake/???.cmake)
+#     # 
+#     else()
+#         message(STATUS "\n-- ###############################################\n")
+#         message(STATUS "Unknow vendor or chip. Supported vendors/chips:\n-- ST's STM32 (e.g. STM32F407VG)\n")
+#         message(STATUS "###############################################\n\n")
+#         message(FATAL_ERROR "Unknow vendor or chip in TARGET_CHIP")
+#     endif()
 
-    # set toolchain file
-    set(CMAKE_TOOLCHAIN_FILE CMake/toolchain.${CHIP_VENDOR_STM32}.${TOOLCHAIN}.cmake)
+#     # set toolchain file
+#     set(CMAKE_TOOLCHAIN_FILE CMake/toolchain.${CHIP_VENDOR_STM32}.${TOOLCHAIN}.cmake)
 endif()
 
 #########################################
@@ -282,336 +287,337 @@ if(RTOS_CHIBIOS_CHECK)
 
     # add TARGET board directory
     add_subdirectory("targets/CMSIS-OS/ChibiOS/${CHIBIOS_BOARD}")
-
-#######################
-# FreeRTOS
-elseif(RTOS_FREERTOS_CHECK)
-
-    # check if FREERTOS_SOURCE was specified or if it's empty (default is empty)
-    set(NO_FREERTOS_SOURCE TRUE)
-    if(FREERTOS_SOURCE)
-        if(NOT "${FREERTOS_SOURCE}" STREQUAL "")
-            set(NO_FREERTOS_SOURCE FALSE)
-        endif()
-    endif()
-
-    if(NO_FREERTOS_SOURCE)
-        # no FreeRTOS source specified, download it from it's repo
-
-        # check for SVN (needed here for advanced warning to user if it's not installed)
-        find_package(Subversion)
-
-        #  check is SVN was found, if not report to user and abort
-        if(NOT Subversion_SVN_EXECUTABLE)
-        message(FATAL_ERROR "error: could not find SVN, make sure you have it installed.")
-        endif()
-
-        # check if build was requested with a specifc FreeRTOS version
-        if(DEFINED FREERTOS_VERSION)
-
-            if("${FREERTOS_VERSION}" STREQUAL "")
-                set(FREERTOS_VERSION_EMPTY TRUE)
-            endif()
-
-            if(FREERTOS_VERSION_EMPTY)
-                # no FreeRTOS version actualy specified, must be empty which is fine, we'll grab the code from the trunk
-                message(STATUS "RTOS is: FreeRTOS (latest available code from trunk)")
-                set(FREERTOS_SVN_REPOSITORY "https://svn.code.sf.net/p/freertos/code/trunk")
-            else()
-                message(STATUS "RTOS is: FreeRTOS v${FREERTOS_VERSION}")
-                set(FREERTOS_SVN_REPOSITORY "https://svn.code.sf.net/p/freertos/code/tags/V${FREERTOS_VERSION}")
-            endif()
-            
-        endif()
-
-        # need to setup a separate CMake project to download the code from the SVN repository
-        # otherwise it won't be available before the actual build step
-        configure_file("CMake/FreeRTOS.CMakeLists.cmake.in"
-                    "${CMAKE_BINARY_DIR}/FreeRTOS_Download/CMakeLists.txt")
-        
-        # setup CMake project for FreeRTOS download
-        execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                        RESULT_VARIABLE result
-                        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/FreeRTOS_Download")
-
-        # run build on FreeRTOS download CMake project to perform the download
-        execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                        RESULT_VARIABLE result
-                        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/FreeRTOS_Download")
-        
-        # add FreeRTOS as external project
-        ExternalProject_Add( 
-            FreeRTOS
-            PREFIX FreeRTOS
-            SOURCE_DIR ${CMAKE_BINARY_DIR}/FreeRTOS_Source
-            SVN_REPOSITORY ${FREERTOS_SVN_REPOSITORY}/FreeRTOS/Source
-            TIMEOUT 10
-            LOG_DOWNLOAD 1
-            # Disable all other steps
-            INSTALL_COMMAND ""
-            CONFIGURE_COMMAND ""
-            BUILD_COMMAND ""
-        )
-
-        # get source dir for FreeRTOS CMake project
-        ExternalProject_Get_Property(FreeRTOS SOURCE_DIR)
-        set(FREERTOS_INCLUDE_DIR ${CMAKE_BINARY_DIR}/FreeRTOS_Source/include)
-
-    else()
-        # FreeRTOS source was specified
-
-        # sanity check is source path exists
-        if(EXISTS "${FREERTOS_SOURCE}/")
-            message(STATUS "RTOS is: FreeRTOS (source from: ${FREERTOS_SOURCE})")
-
-            file(COPY "${FREERTOS_SOURCE}/" DESTINATION "${CMAKE_BINARY_DIR}/FreeRTOS_Source")
-            set(FREERTOS_INCLUDE_DIR ${CMAKE_BINARY_DIR}/FreeRTOS_Source/include)
-        else()
-            message(FATAL_ERROR "Couldn't find FreeRTOS source at ${FREERTOS_SOURCE}/")
-        endif()
-
-    endif()
-
-    # set CMSIS RTOS include directory
-    include_directories( ${CMSIS_RTOS_INCLUDE_DIR})
-   
-    # add source directory
-    add_subdirectory("src")
-
-#######################
-# mbed OS
-elseif(RTOS_MBEDOS_CHECK)
-
-    # check if MBEDOS_SOURCE was specified or if it's empty (default is empty)
-    set(NO_MBEDOS_SOURCE TRUE)
-    if(MBEDOS_SOURCE)
-        if(NOT "${MBEDOS_SOURCE}" STREQUAL "")
-            set(NO_MBEDOS_SOURCE FALSE)
-        endif()
-    endif()
-
-    # check is a target was specified
-    if(MBED_TARGET)
-        if(NOT "${MBEDOS_SOURCE}" STREQUAL "")
-            message(FATAL_ERROR "\n\nYou need to specify a valid ${MBED_TARGET} when mbed OS is the RTOS option\n\n")
-        endif()
-    else()
-        message(FATAL_ERROR "\n\nYou need to specify a valid ${MBED_TARGET} when mbed OS is the RTOS option\n\n")
-    endif()
-
-    if(NO_MBEDOS_SOURCE)
-        # no mbed RTOS source specified, download it from it's repo
-
-        # hack to make the FindGit to work in Windows platforms (check the module comment for details)
-        include(Hack_SetGitSearchPath)
-
-        # check for Git (needed here for advanced warning to user if it's not installed)
-        find_package(Git)
-
-        #  check if Git was found, if not report to user and abort
-        if(NOT GIT_EXECUTABLE)
-        message(FATAL_ERROR "error: could not find Git, make sure you have it installed.")
-        endif()
-
-        message(STATUS "RTOS is: mbed RTOS (latest available code from GitHub repo)")
-
-        # need to setup a separate CMake project to download the code from the SVN repository
-        # otherwise it won't be available before the actual build step
-        configure_file("CMake/mbedOS.CMakeLists.cmake.in"
-                    "${CMAKE_BINARY_DIR}/mbedOS_Download/CMakeLists.txt")
-        
-        # setup CMake project for mbed RTOS download
-        execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                        RESULT_VARIABLE result
-                        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/mbedOS_Download")
-
-        # run build on mbed RTOS download CMake project to perform the download
-        execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                        RESULT_VARIABLE result
-                        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/mbedOS_Download")
-               
-        # download mbedOS source from official GitHub repo
-        ExternalProject_Add( 
-            mbedOS
-            PREFIX mbed-OS
-            SOURCE_DIR ${CMAKE_BINARY_DIR}/mbedOS_Source
-            GIT_REPOSITORY  https://github.com/ARMmbed/mbed-os/
-            GIT_TAG master  # target master branch
-            GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
-            TIMEOUT 10
-            LOG_DOWNLOAD 1
-            
-            # Disable all other steps
-            CONFIGURE_COMMAND ""
-            BUILD_COMMAND ""
-            INSTALL_COMMAND ""
-        )
-
-        # get source dir for mbed RTOS CMake project
-        # ExternalProject_Get_Property(mbedOS SOURCE_DIR)
-        # set(MBEDOS_INCLUDE_DIRS ${MBEDOS_SOURCE_DIR})
-
-        # set update disconnected to prevent updates on builds
-        set_property(DIRECTORY ${MBEDOS_SOURCE_DIR} PROPERTY EP_UPDATE_DISCONNECTED 1)
-
-    else()
-        # mbed OS source location was specified
-
-        if(NOT EXISTS "${PROJECT_BINARY_DIR}/mbedOS_Source")
-            # need to copy srouce to build directory
-            message(STATUS "RTOS is: mbed OS (copying source from: ${MBEDOS_SOURCE})")
-
-            file(COPY "${MBEDOS_SOURCE}/" DESTINATION "${PROJECT_BINARY_DIR}/mbedOS_Source")
-        elseif()
-            # source directory  already at build folder so we are done here
-            message(STATUS "RTOS is: mbed OS (source from: ${MBEDOS_SOURCE} already at build directory)")
-        endif()
-
-        # set(MBEDOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/mbedOS_Source)
-
-    endif()
-
-    # find_package(MBEDOPTIONS REQUIRED)
-   
-    # add source directory
-    add_subdirectory("targets/os/mbed-os/nanoBooter")
-
-#######################
-# RTX RTOS
-elseif(RTOS_RTX_RTOS_CHECK)
-
-    # hack to make the FindGit to work in Windows platforms (check the module comment for details)
-    include(Hack_SetGitSearchPath)
-
-    # check for Git (needed here for advanced warning to user if it's not installed)
-    find_package(Git)
-
-    #  check if Git was found, if not report to user and abort
-    if(NOT GIT_EXECUTABLE)
-      message(FATAL_ERROR "error: could not find Git, make sure you have it installed.")
-    endif()
-
-    # need to setup a separate CMake project to download the code from the SVN repository
-    # otherwise it won't be available before the actual build step
-    configure_file("CMake/RTXRTOS.CMakeLists.cmake.in"
-                   "${CMAKE_BINARY_DIR}/RTXRTOS_Download/CMakeLists.txt")
-    
-    # setup CMake project for RTX RTOS download
-    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                    RESULT_VARIABLE result
-                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/RTXRTOS_Download")
-
-    # run build on RTX RTOS download CMake project to perform the download
-    execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                    RESULT_VARIABLE result
-                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/RTXRTOS_Download")
-    
-    # download RTX RTOS source from official GitHub repo
-    ExternalProject_Add( 
-        RTXRTOS
-        PREFIX RTX-RTOS
-        SOURCE_DIR ${CMAKE_BINARY_DIR}/RTXRTOS_Source
-        GIT_REPOSITORY  https://github.com/ARM-software/CMSIS_5
-        GIT_TAG master  # target master branch
-        GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
-        TIMEOUT 10
-        LOG_DOWNLOAD 1
-        
-        # Disable all other steps
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-        INSTALL_COMMAND ""
-    )
-
-    # get source dir for RTX RTOS CMake project
-    ExternalProject_Get_Property(RTXRTOS SOURCE_DIR)
-    set(RTXRTOS_INCLUDE_DIRS ${RTXRTOS_SOURCE_DIR})
-   
-    # add source directory
-    add_subdirectory("src")
-
-#######################
-# RTX RTOS2
-elseif(RTOS_RTX_RTOS2_CHECK)
-
-    message(FATAL_ERROR "
-#############################################################
-support for RTX RTOS2 is in the works, please check latter...
-#############################################################")
-
-    # hack to make the FindGit to work in Windows platforms (check the module comment for details)
-    include(Hack_SetGitSearchPath)
-
-    # check for Git (needed here for advanced warning to user if it's not installed)
-    find_package(Git)
-
-    #  check if Git was found, if not report to user and abort
-    if(NOT GIT_EXECUTABLE)
-      message(FATAL_ERROR "error: could not find Git, make sure you have it installed.")
-    endif()
-
-    # need to setup a separate CMake project to download the code from the SVN repository
-    # otherwise it won't be available before the actual build step
-    configure_file("CMake/RTXRTOS.CMakeLists.cmake.in"
-                   "${CMAKE_BINARY_DIR}/RTXRTOS_Download/CMakeLists.txt")
-    
-    # setup CMake project for RTX RTOS2 download (same as RTX RTOS)
-    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                    RESULT_VARIABLE result
-                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/RTXRTOS_Download")
-
-    # run build on RTX RTOS2 download CMake project to perform the download
-    execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                    RESULT_VARIABLE result
-                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/RTXRTOS_Download")
-    
-    # download RTX RTOS2 source from official GitHub repo (same as RTX RTOS)
-    ExternalProject_Add( 
-        RTXRTOS2
-        PREFIX RTX-RTOS
-        SOURCE_DIR ${CMAKE_BINARY_DIR}/RTXRTOS_Source
-        GIT_REPOSITORY  https://github.com/ARM-software/CMSIS_5
-        GIT_TAG master  # target master branch
-        GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
-        TIMEOUT 10
-        LOG_DOWNLOAD 1
-        
-        # Disable all other steps
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-        INSTALL_COMMAND ""
-    )
-
-    # get source dir for RTX RTOS2 CMake project
-    ExternalProject_Get_Property(RTXRTOS2 SOURCE_DIR)
-    set(RTXRTOS2_INCLUDE_DIRS ${RTXRTOS2_SOURCE_DIR})
-   
-    # add source directory
-    add_subdirectory("src")
-
-#######################
-
-# no RTOS specifed
-else()
-    
-    set(NORTOS TRUE)
-
-    message(STATUS "NO RTOS was specified")
-
-    # include CMSIS, HAL and drivers  
-    if(CHIP_VENDOR_STM32_CHECK)
-        # vendor is ST, chip is STM32
-
-        # ST Cube package with CMSIS and SMT32 HAL
-        add_subdirectory("stcube_repository")
-
-    # elseif(CHIP_VENDOR_??_CHECK)
-    #
-    #     # vendor is ?? and toolchain is GCC
-    #     add_subdirectory("???")
-    endif()    
-   
-    # add source directory
-    add_subdirectory("src")
- 
 endif()
+
+# #######################
+# # FreeRTOS
+# elseif(RTOS_FREERTOS_CHECK)
+
+#     # check if FREERTOS_SOURCE was specified or if it's empty (default is empty)
+#     set(NO_FREERTOS_SOURCE TRUE)
+#     if(FREERTOS_SOURCE)
+#         if(NOT "${FREERTOS_SOURCE}" STREQUAL "")
+#             set(NO_FREERTOS_SOURCE FALSE)
+#         endif()
+#     endif()
+
+#     if(NO_FREERTOS_SOURCE)
+#         # no FreeRTOS source specified, download it from it's repo
+
+#         # check for SVN (needed here for advanced warning to user if it's not installed)
+#         find_package(Subversion)
+
+#         #  check is SVN was found, if not report to user and abort
+#         if(NOT Subversion_SVN_EXECUTABLE)
+#         message(FATAL_ERROR "error: could not find SVN, make sure you have it installed.")
+#         endif()
+
+#         # check if build was requested with a specifc FreeRTOS version
+#         if(DEFINED FREERTOS_VERSION)
+
+#             if("${FREERTOS_VERSION}" STREQUAL "")
+#                 set(FREERTOS_VERSION_EMPTY TRUE)
+#             endif()
+
+#             if(FREERTOS_VERSION_EMPTY)
+#                 # no FreeRTOS version actualy specified, must be empty which is fine, we'll grab the code from the trunk
+#                 message(STATUS "RTOS is: FreeRTOS (latest available code from trunk)")
+#                 set(FREERTOS_SVN_REPOSITORY "https://svn.code.sf.net/p/freertos/code/trunk")
+#             else()
+#                 message(STATUS "RTOS is: FreeRTOS v${FREERTOS_VERSION}")
+#                 set(FREERTOS_SVN_REPOSITORY "https://svn.code.sf.net/p/freertos/code/tags/V${FREERTOS_VERSION}")
+#             endif()
+            
+#         endif()
+
+#         # need to setup a separate CMake project to download the code from the SVN repository
+#         # otherwise it won't be available before the actual build step
+#         configure_file("CMake/FreeRTOS.CMakeLists.cmake.in"
+#                     "${CMAKE_BINARY_DIR}/FreeRTOS_Download/CMakeLists.txt")
+        
+#         # setup CMake project for FreeRTOS download
+#         execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+#                         RESULT_VARIABLE result
+#                         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/FreeRTOS_Download")
+
+#         # run build on FreeRTOS download CMake project to perform the download
+#         execute_process(COMMAND ${CMAKE_COMMAND} --build .
+#                         RESULT_VARIABLE result
+#                         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/FreeRTOS_Download")
+        
+#         # add FreeRTOS as external project
+#         ExternalProject_Add( 
+#             FreeRTOS
+#             PREFIX FreeRTOS
+#             SOURCE_DIR ${CMAKE_BINARY_DIR}/FreeRTOS_Source
+#             SVN_REPOSITORY ${FREERTOS_SVN_REPOSITORY}/FreeRTOS/Source
+#             TIMEOUT 10
+#             LOG_DOWNLOAD 1
+#             # Disable all other steps
+#             INSTALL_COMMAND ""
+#             CONFIGURE_COMMAND ""
+#             BUILD_COMMAND ""
+#         )
+
+#         # get source dir for FreeRTOS CMake project
+#         ExternalProject_Get_Property(FreeRTOS SOURCE_DIR)
+#         set(FREERTOS_INCLUDE_DIR ${CMAKE_BINARY_DIR}/FreeRTOS_Source/include)
+
+#     else()
+#         # FreeRTOS source was specified
+
+#         # sanity check is source path exists
+#         if(EXISTS "${FREERTOS_SOURCE}/")
+#             message(STATUS "RTOS is: FreeRTOS (source from: ${FREERTOS_SOURCE})")
+
+#             file(COPY "${FREERTOS_SOURCE}/" DESTINATION "${CMAKE_BINARY_DIR}/FreeRTOS_Source")
+#             set(FREERTOS_INCLUDE_DIR ${CMAKE_BINARY_DIR}/FreeRTOS_Source/include)
+#         else()
+#             message(FATAL_ERROR "Couldn't find FreeRTOS source at ${FREERTOS_SOURCE}/")
+#         endif()
+
+#     endif()
+
+#     # set CMSIS RTOS include directory
+#     include_directories( ${CMSIS_RTOS_INCLUDE_DIR})
+   
+#     # add source directory
+#     add_subdirectory("src")
+
+# #######################
+# # mbed OS
+# elseif(RTOS_MBEDOS_CHECK)
+
+#     # check if MBEDOS_SOURCE was specified or if it's empty (default is empty)
+#     set(NO_MBEDOS_SOURCE TRUE)
+#     if(MBEDOS_SOURCE)
+#         if(NOT "${MBEDOS_SOURCE}" STREQUAL "")
+#             set(NO_MBEDOS_SOURCE FALSE)
+#         endif()
+#     endif()
+
+#     # check is a target was specified
+#     if(MBED_TARGET)
+#         if(NOT "${MBEDOS_SOURCE}" STREQUAL "")
+#             message(FATAL_ERROR "\n\nYou need to specify a valid ${MBED_TARGET} when mbed OS is the RTOS option\n\n")
+#         endif()
+#     else()
+#         message(FATAL_ERROR "\n\nYou need to specify a valid ${MBED_TARGET} when mbed OS is the RTOS option\n\n")
+#     endif()
+
+#     if(NO_MBEDOS_SOURCE)
+#         # no mbed RTOS source specified, download it from it's repo
+
+#         # hack to make the FindGit to work in Windows platforms (check the module comment for details)
+#         include(Hack_SetGitSearchPath)
+
+#         # check for Git (needed here for advanced warning to user if it's not installed)
+#         find_package(Git)
+
+#         #  check if Git was found, if not report to user and abort
+#         if(NOT GIT_EXECUTABLE)
+#         message(FATAL_ERROR "error: could not find Git, make sure you have it installed.")
+#         endif()
+
+#         message(STATUS "RTOS is: mbed RTOS (latest available code from GitHub repo)")
+
+#         # need to setup a separate CMake project to download the code from the SVN repository
+#         # otherwise it won't be available before the actual build step
+#         configure_file("CMake/mbedOS.CMakeLists.cmake.in"
+#                     "${CMAKE_BINARY_DIR}/mbedOS_Download/CMakeLists.txt")
+        
+#         # setup CMake project for mbed RTOS download
+#         execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+#                         RESULT_VARIABLE result
+#                         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/mbedOS_Download")
+
+#         # run build on mbed RTOS download CMake project to perform the download
+#         execute_process(COMMAND ${CMAKE_COMMAND} --build .
+#                         RESULT_VARIABLE result
+#                         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/mbedOS_Download")
+               
+#         # download mbedOS source from official GitHub repo
+#         ExternalProject_Add( 
+#             mbedOS
+#             PREFIX mbed-OS
+#             SOURCE_DIR ${CMAKE_BINARY_DIR}/mbedOS_Source
+#             GIT_REPOSITORY  https://github.com/ARMmbed/mbed-os/
+#             GIT_TAG master  # target master branch
+#             GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
+#             TIMEOUT 10
+#             LOG_DOWNLOAD 1
+            
+#             # Disable all other steps
+#             CONFIGURE_COMMAND ""
+#             BUILD_COMMAND ""
+#             INSTALL_COMMAND ""
+#         )
+
+#         # get source dir for mbed RTOS CMake project
+#         # ExternalProject_Get_Property(mbedOS SOURCE_DIR)
+#         # set(MBEDOS_INCLUDE_DIRS ${MBEDOS_SOURCE_DIR})
+
+#         # set update disconnected to prevent updates on builds
+#         set_property(DIRECTORY ${MBEDOS_SOURCE_DIR} PROPERTY EP_UPDATE_DISCONNECTED 1)
+
+#     else()
+#         # mbed OS source location was specified
+
+#         if(NOT EXISTS "${PROJECT_BINARY_DIR}/mbedOS_Source")
+#             # need to copy srouce to build directory
+#             message(STATUS "RTOS is: mbed OS (copying source from: ${MBEDOS_SOURCE})")
+
+#             file(COPY "${MBEDOS_SOURCE}/" DESTINATION "${PROJECT_BINARY_DIR}/mbedOS_Source")
+#         elseif()
+#             # source directory  already at build folder so we are done here
+#             message(STATUS "RTOS is: mbed OS (source from: ${MBEDOS_SOURCE} already at build directory)")
+#         endif()
+
+#         # set(MBEDOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/mbedOS_Source)
+
+#     endif()
+
+#     # find_package(MBEDOPTIONS REQUIRED)
+   
+#     # add source directory
+#     add_subdirectory("targets/os/mbed-os/nanoBooter")
+
+# #######################
+# # RTX RTOS
+# elseif(RTOS_RTX_RTOS_CHECK)
+
+#     # hack to make the FindGit to work in Windows platforms (check the module comment for details)
+#     include(Hack_SetGitSearchPath)
+
+#     # check for Git (needed here for advanced warning to user if it's not installed)
+#     find_package(Git)
+
+#     #  check if Git was found, if not report to user and abort
+#     if(NOT GIT_EXECUTABLE)
+#       message(FATAL_ERROR "error: could not find Git, make sure you have it installed.")
+#     endif()
+
+#     # need to setup a separate CMake project to download the code from the SVN repository
+#     # otherwise it won't be available before the actual build step
+#     configure_file("CMake/RTXRTOS.CMakeLists.cmake.in"
+#                    "${CMAKE_BINARY_DIR}/RTXRTOS_Download/CMakeLists.txt")
+    
+#     # setup CMake project for RTX RTOS download
+#     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+#                     RESULT_VARIABLE result
+#                     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/RTXRTOS_Download")
+
+#     # run build on RTX RTOS download CMake project to perform the download
+#     execute_process(COMMAND ${CMAKE_COMMAND} --build .
+#                     RESULT_VARIABLE result
+#                     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/RTXRTOS_Download")
+    
+#     # download RTX RTOS source from official GitHub repo
+#     ExternalProject_Add( 
+#         RTXRTOS
+#         PREFIX RTX-RTOS
+#         SOURCE_DIR ${CMAKE_BINARY_DIR}/RTXRTOS_Source
+#         GIT_REPOSITORY  https://github.com/ARM-software/CMSIS_5
+#         GIT_TAG master  # target master branch
+#         GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
+#         TIMEOUT 10
+#         LOG_DOWNLOAD 1
+        
+#         # Disable all other steps
+#         CONFIGURE_COMMAND ""
+#         BUILD_COMMAND ""
+#         INSTALL_COMMAND ""
+#     )
+
+#     # get source dir for RTX RTOS CMake project
+#     ExternalProject_Get_Property(RTXRTOS SOURCE_DIR)
+#     set(RTXRTOS_INCLUDE_DIRS ${RTXRTOS_SOURCE_DIR})
+   
+#     # add source directory
+#     add_subdirectory("src")
+
+# #######################
+# # RTX RTOS2
+# elseif(RTOS_RTX_RTOS2_CHECK)
+
+#     message(FATAL_ERROR "
+# #############################################################
+# support for RTX RTOS2 is in the works, please check latter...
+# #############################################################")
+
+#     # hack to make the FindGit to work in Windows platforms (check the module comment for details)
+#     include(Hack_SetGitSearchPath)
+
+#     # check for Git (needed here for advanced warning to user if it's not installed)
+#     find_package(Git)
+
+#     #  check if Git was found, if not report to user and abort
+#     if(NOT GIT_EXECUTABLE)
+#       message(FATAL_ERROR "error: could not find Git, make sure you have it installed.")
+#     endif()
+
+#     # need to setup a separate CMake project to download the code from the SVN repository
+#     # otherwise it won't be available before the actual build step
+#     configure_file("CMake/RTXRTOS.CMakeLists.cmake.in"
+#                    "${CMAKE_BINARY_DIR}/RTXRTOS_Download/CMakeLists.txt")
+    
+#     # setup CMake project for RTX RTOS2 download (same as RTX RTOS)
+#     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+#                     RESULT_VARIABLE result
+#                     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/RTXRTOS_Download")
+
+#     # run build on RTX RTOS2 download CMake project to perform the download
+#     execute_process(COMMAND ${CMAKE_COMMAND} --build .
+#                     RESULT_VARIABLE result
+#                     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/RTXRTOS_Download")
+    
+#     # download RTX RTOS2 source from official GitHub repo (same as RTX RTOS)
+#     ExternalProject_Add( 
+#         RTXRTOS2
+#         PREFIX RTX-RTOS
+#         SOURCE_DIR ${CMAKE_BINARY_DIR}/RTXRTOS_Source
+#         GIT_REPOSITORY  https://github.com/ARM-software/CMSIS_5
+#         GIT_TAG master  # target master branch
+#         GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
+#         TIMEOUT 10
+#         LOG_DOWNLOAD 1
+        
+#         # Disable all other steps
+#         CONFIGURE_COMMAND ""
+#         BUILD_COMMAND ""
+#         INSTALL_COMMAND ""
+#     )
+
+#     # get source dir for RTX RTOS2 CMake project
+#     ExternalProject_Get_Property(RTXRTOS2 SOURCE_DIR)
+#     set(RTXRTOS2_INCLUDE_DIRS ${RTXRTOS2_SOURCE_DIR})
+   
+#     # add source directory
+#     add_subdirectory("src")
+
+# #######################
+
+# # no RTOS specifed
+# else()
+    
+#     set(NORTOS TRUE)
+
+#     message(STATUS "NO RTOS was specified")
+
+#     # include CMSIS, HAL and drivers  
+#     if(CHIP_VENDOR_STM32_CHECK)
+#         # vendor is ST, chip is STM32
+
+#         # ST Cube package with CMSIS and SMT32 HAL
+#         add_subdirectory("stcube_repository")
+
+#     # elseif(CHIP_VENDOR_??_CHECK)
+#     #
+#     #     # vendor is ?? and toolchain is GCC
+#     #     add_subdirectory("???")
+#     endif()    
+   
+#     # add source directory
+#     add_subdirectory("src")
+ 
+# endif()

--- a/docs/build-instructions.md
+++ b/docs/build-instructions.md
@@ -40,21 +40,15 @@ As a suggestion we recommend that you create a directory named *build* in the re
 # Build a **nanoFramework** image
 
 The build script accepts the following parameters (some of them are mandatory).
-- TARGET_CHIP: this is the vendor reference to the chip that you are building the image for. At this time only STM32F4 series are supported. A valid reference here would be STM32F407VG.
-- PACKAGE_VERSION: In case you are building for an STM32 chip this is the package version of the ST Cube package (with the CMSIS and HAL drivers) that you want to use. This will be downloaded from ST web site except if the package already exists in the ST Cube repository folder. A valid package number is required. E.g.: 1.3.0 or 1.41.2.  
 - TOOLCHAIN: the toolchain to use in the build. The default (and only option at this time) is GCC.
 - TOOLCHAIN_PREFIX: path to the install directory of the toolchain. E.g.: "E:/GNU_Tools_ARM_Embedded/5_4_2016q3". Mind the forward slash on the path for all platforms.
 - CMAKE_BUILD_TYPE: build type (Debug, Release, etc). The default is Release.
-- RTOS: specifies the RTOS to add to the image. If no source path is specified the source files will be downloaded from the respective repository. Current valid RTOSes are FreeRTOS (FREERTOS), mbed OS (MBEDRTOS), ChibiOS (CHIBIOS) and ARM RTX (RTXRTOS).
-- FREERTOS_VERSION: specifies the FreeRTOS version to grab the source files. It has to match one of the official versions from the FreeRTOS repository. If none is specified it will download the 'trunk' version. This parameter is ignored if FREERTOS_SOURCE is specified. 
-- FREERTOS_SOURCE: specifies the path for the location of the FreeRTOS source code. If this parameter is specified the code on that path will be used and no download is performed. For this parameter to be valid RTOS must be specified with FREERTOS option. 
-- MBED_SOURCE: specifies the path for the location of the mBed source code. If this parameter is specified the code on that path will be used and no download is performed. For this parameter to be valid RTOS parameter must be specified with MBEDRTOS option. 
-- MBED_TARGET: specifies the mBed OS target. This parameter is mandatory when specifying MBEDRTOS as the RTOS choice parameter above. It has to be a valid target listed in mBed OS _targets.json_ file.
 - CHIBIOS_SOURCE: specifies the path for the location of the ChibiOS source code. If this parameter is specified the code on that path will be used and no download is performed. For this parameter to be valid RTOS parameter must be specified with CHIBIOS option. 
 - CHIBIOS_VERSION: specifies the ChibiOS version to grab the source files. It has to match one of the official versions from the ChibiOS repository. If none is specified it will download the 'trunk' version. This parameter is ignored if CHIBIOS_SOURCE is specified. 
 - CHIBIOS_BOARD: specifies the ChibiOS board. This parameter is mandatory when specifying CHIBIOS as the RTOS choice parameter above. It has to be a valid board listed in ChibiOS boards folder.
 
-_Note: the very first build will take more or less time depending on the download speed of the Internet connection of the machine were the build is running. This is because the source code of the RTOS of your choice will be downloaded from its repository. On the subsequent builds this won't happen._
+_Note 1: The RTOS currently supported is ChibiOS. If no source path is specified the source files will be downloaded from it's official GitHub mirror._
+_Note 2: the very first build will take more or less time depending on the download speed of the Internet connection of the machine were the build is running. This is because the source code of the RTOS of your choice will be downloaded from its repository. On the subsequent builds this won't happen._
 
 You can specify any generator that is supported in the platform where you are building.
 For more information on this check CMake documentation [here](https://cmake.org/cmake/help/v3.7/manual/cmake-generators.7.html?highlight=generator).
@@ -68,28 +62,24 @@ The following is a working example:
 ```
 cmake \
 -DTOOLCHAIN_PREFIX="E:/GNU_Tools_ARM_Embedded/5_4_2016q3" \
--DTARGET_CHIP=STM32F407VG \
--DPACKAGE_VERSION=1.13.1 \
--RTOS=FREERTOS \
--FREERTOS_VERSION=9.0.0 \
+-DCHIBIOS_VERSION=16.1.7 \
+-DCHIBIOS_BOARD=ST_NUCLEO_F091RC \
 -G "NMake Makefiles" ../ 
 ```
 
-This will call CMake (on your *build* directory that is assumed to be under the repository root) specifying the location of the toolchain install, targeting STM32F407VG, asking for the ST Cube package version 1.13.1 to be used, specifying FreeRTOS v9.0.0 as the RTOS and that the build files suitable for NMake are to be generated.
+This will call CMake (on your *build* directory that is assumed to be under the repository root) specifying the location of the toolchain install, specifying ChibiOS v16.1.7 as the RTOS version, that the target board is named ST_NUCLEO_F091RC and that the build files suitable for NMake are to be generated.
 
 Another example:
 
 ```
 cmake \
 -DTOOLCHAIN_PREFIX="E:/GNU_Tools_ARM_Embedded/5_4_2016q3" \
--DTARGET_CHIP=STM32F091RC \
--DPACKAGE_VERSION=1.6.0 \
--RTOS=MBEDRTOS \
--MBEDRTOS_SOURCE=E:/GitHub/mbed-os \
+-DCHIBIOS_SOURCE=E:/GitHub/ChibiOS \
+-DCHIBIOS_BOARD=ST_NUCLEO144_F746ZG \
 -G "NMake Makefiles" ../ 
 ```
 
-This will call CMake (on your *build* directory that is assumed to be under the repository root) specifying the location of the toolchain install, targeting STM32F091RC, asking for the ST Cube package version 1.6.0 to be used, specifying MBEDRTOS as the RTOS, that mBed RTOS sources are located in the designated path (mind the forward slash and no ending slash) and that the build files suitable for NMake are to be generated.
+This will call CMake (on your *build* directory that is assumed to be under the repository root) specifying the location of the toolchain install, specifying that ChibiOS sources to be used are located in the designated path (mind the forward slash and no ending slash),  that the target board is named ST_NUCLEO144_F746ZG and that the build files suitable for NMake are to be generated.
 
 After successful completion you'll have the build files ready to be used in the target build tool.
 
@@ -121,4 +111,4 @@ After a successful build you can find the **nanoFramework** image files in the *
   - nanoCLR.hex (Intel hex format)
   - nanoCLR.s19 (Motorola S-record format, equivalent to srec)
   - nanoCLR.lst (source code listing intermixed with disassembly)
-  - nanoCLR.map (image map) 
+  - nanoCLR.map (image map)


### PR DESCRIPTION
comment code sections for unsupported RTOSes in main CMake
Documentation:
remove options that are not supported in the current iteration (ChibiOS
is the only supported RTOS and HAL)
correct example command lines

Signed-off-by: José Simões jose.simoes@eclo.solutions